### PR TITLE
ZGD-4: Move page content into top-level landmarks

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const Footer = () => (
-  <div style={{ textAlign: 'center', fontSize: '.75em', fontWeight: 700, margin: '0 auto', padding: '.5em', width: '90vw', borderTop: `1px dotted black`}}>
+  <footer style={{ textAlign: 'center', fontSize: '.75em', fontWeight: 700, margin: '0 auto', padding: '.5em', width: '90vw', borderTop: `1px dotted black`}}>
     Copyright 2019, <a href="https://github.com/detroit-urban-tech-meetup/zoning-guide-detroit">Zoning Guide Detroit</a> contributors. This project is open source.
-  </div>
+  </footer>
 )
 
 export default Footer;

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -38,14 +38,14 @@ const Header = ({ siteTitle }) => (
           {siteTitle}
         </Link>
       </div>
-    <div style={{display: 'flex'}}>
+    <nav style={{display: 'flex'}}>
       <Link to={`/`} style={linkStyle}>Home</Link>
       <Link to={`/zones`} style={linkStyle}>Zones</Link>
       <Link to={`/uses`} style={linkStyle}>Uses</Link>
       <Link to={`/map`} style={linkStyle}>Map</Link>
       <Link to={`/links`} style={linkStyle}>Links</Link>
       <Link to={`/about`} style={linkStyle}>About</Link>
-    </div>
+    </nav>
     </div>
   </header>
 )

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -27,7 +27,7 @@ const Layout = ({ children, fullscreen }) => {
   return (
     <>
       <Header siteTitle={data.site.siteMetadata.title} />
-      <div
+      <main
         style={{
           margin: `0 auto`,
           maxWidth: fullscreen ? '100vw' : 1080,
@@ -35,8 +35,8 @@ const Layout = ({ children, fullscreen }) => {
           paddingTop: 0,
         }}
       >
-        <main>{children}</main>
-      </div>
+        <div>{children}</div>
+      </main>
       <Footer />
     </>
   )


### PR DESCRIPTION
Added top level `<main>` and `<footer>` elements and a `<nav>` element within the page header in accordance with [Web Accessibility Content Guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html).

This closes issue #4.